### PR TITLE
Androidにおいてペイロード受け取り通知がアプリに渡されない。

### DIFF
--- a/source/proj.android/src/com/growthpush/Cocos2dxReceiverService.java
+++ b/source/proj.android/src/com/growthpush/Cocos2dxReceiverService.java
@@ -4,8 +4,6 @@ import com.growthpush.bridge.ExternalFrameworkReceiverService;
 
 public class Cocos2dxReceiverService extends ExternalFrameworkReceiverService {
 
-    private com.growthpush.Cocos2dxBridge bridge;
-
     public Cocos2dxReceiverService() {
         super();
         this.bridge = new com.growthpush.Cocos2dxBridge();


### PR DESCRIPTION
Cocos2d-x v3.11アプリにおいて Growthbeat v1.2.6からv2.0.4へのアップデートで起こった不具合です。v2.x系を初めて使う場合には起こらないかは不明なので，ご参考程度に見ていただければと思います。
# 概要

プッシュ通知からアプリを起動する際にカスタムフィールド(ペイロード)がうまくcocos2d-x(C++)側に渡されないという不具合が起こりました。
# 原因

`Cocos2dxReceiverService` のメンバである `bridge` がスーパークラスの `bridge` を隠蔽しているため
# 修正内容

サブクラスの `bridge` を削除してスーパークラスのものへ代入するように変更した。
結果，カスタムフィールドを受け取ることができた。 

サブクラスへ `bridge` を追加した明確な理由があるのであれば，コメントにて教えてくださるととてもありがたいです。(利用の際になにか不具合がでてしまう？)
